### PR TITLE
Allow form reset on initialValues change

### DIFF
--- a/react/Form.tsx
+++ b/react/Form.tsx
@@ -110,11 +110,13 @@ class Form extends React.PureComponent<Props> {
 
   render() {
     const { initialValues, onSubmit, children, validationSchema, id } = this.props
+
     return (
       <Formik
         initialValues={initialValues}
         onSubmit={onSubmit}
         validationSchema={validationSchema}
+        enableReinitialize
       >
         {(formikProps: FormikProps<{ [key: string]: any }>) => (
           <form onSubmit={formikProps.handleSubmit} id={id}>


### PR DESCRIPTION
#### What does this PR do? \*
Enable form reset when `initialValues` change. It's necessary on edit forms, where the `initialValues` depends on an API call.

#### How to test it? \*
https://augusto--mystore.mygocommerce.com/admin/marketing/promotions/edit/86bbd7de-145a-4ab0-be46-70721b51415f/

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
