### PR TITLE
Add country select

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,10 +25,11 @@ This app is based on the [vtex](https://styleguide.vtex.com/) and [gocommerce](h
 - Toggle
 - Textarea
 - Select
+- SelectCountry
 - DatePicker
 - SubmitButton
 
-## Usage
+## Simple example
 
 ```js
 <Form
@@ -43,17 +44,55 @@ This app is based on the [vtex](https://styleguide.vtex.com/) and [gocommerce](h
     age: 12,
   }}
 >
-  <Form.Input
-    id="name"
-    name="name"
-    label="What's your name?"
-  />
-
-  <Form.Input
-    id="age"
-    name="age"
-    type="number"
-    label="How old are you?"
-  />
+  {(formData: any) => {
+    const { values, setFieldValue, initialValues, errors, submitCount, touched } = formData
+    return (
+      <>
+        <Form.Input
+          id="name"
+          name="name"
+          label="What's your name?"
+        />
+        <Form.Input
+          id="age"
+          name="age"
+          type="number"
+          label="How old are you?"
+        />
+      </>
+    )
+  }}
 </Form>
 ```
+
+## Some other features
+### Masked input
+```js
+<Form.Input
+  id="telephone"
+  name="telephone"
+  label="Type your telephone"
+  mask="(99) 99999-9999"
+/>
+```
+### Select country
+Select a country from all avaiable countries.
+```js
+<Form.SelectCountry
+  id="country"
+  name="country"
+  label="Select a country from all available countries"
+  language={'pt-br'}
+/>
+```
+Select a country from a list of specific countries.
+```js
+<Form.SelectCountry
+  id="country"
+  name="country"
+  label="Select a country"
+  language={'pt-br'}
+  includedCountries={['BRA', 'ARG']}
+/>
+```
+The default language is english and the default countries list are all available countries.

--- a/react/Form.tsx
+++ b/react/Form.tsx
@@ -15,6 +15,7 @@ import {
 import MaskedInput from 'react-text-mask'
 
 import Wrapper from './FieldWrapper'
+import { getCountries } from './utils/countries'
 
 
 interface Props {
@@ -95,6 +96,16 @@ class Form extends React.PureComponent<Props> {
       {wrapperProps => <Select {...wrapperProps} />}
     </Wrapper>
   )
+
+  static SelectCountry = props => {
+    const countryOptions = getCountries(props?.includedCountries, props?.language)
+    const selectCountryProps = { ...props, options: countryOptions }
+    return (
+      <Wrapper formType="SelectCountry" {...selectCountryProps}>
+        {wrapperProps => <Select {...wrapperProps} />}
+      </Wrapper>
+    )
+  }
 
   static Checkbox = props => (
     <Wrapper formType="CheckBox" {...props} type="checkbox">

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,8 @@
     "react-apollo": "^3.1.3",
     "react-dom": "^16.12.0",
     "react-intl": "^3.12.0",
-    "react-text-mask": "^5.4.3"
+    "react-text-mask": "^5.4.3",
+    "i18n-country-code": "^1.0.0"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.1.3",

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -1,0 +1,1 @@
+declare module 'i18n-country-code/locales/*.json'

--- a/react/utils/countries.ts
+++ b/react/utils/countries.ts
@@ -1,0 +1,21 @@
+import countries_en from 'i18n-country-code/locales/en.json'
+import countries_pt from 'i18n-country-code/locales/pt.json'
+import countries_es from 'i18n-country-code/locales/es.json'
+
+export const getCountries = (includedCountries: string[] | undefined, language: string = 'en-us') => {
+  const languageBase = language.split('-')[0]
+  const countries =
+    (languageBase === 'en' && countries_en) ||
+    (languageBase === 'pt' && countries_pt) ||
+    (languageBase === 'es' && countries_es)
+
+  return Object.keys(countries).reduce((prev: any, element: any) => {
+    if (includedCountries) {
+      if (includedCountries.includes(element)) {
+        return [...prev, { label: countries[element], value: element }]
+      }
+      return prev
+    }
+    return [...prev, { label: countries[element], value: element }]
+  }, [])
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2990,6 +2990,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+i18n-country-code@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/i18n-country-code/-/i18n-country-code-1.0.1.tgz#4e20bca28b499d6b39a0f452f29a000c9e508127"
+  integrity sha512-XXItag83EV+M6bMXMqSh81zvY7ULAgl0CRM0vMmBvg7XHLnJdqm2eNOKj+VdDrrLsixHhhjoy7LI6p1LC+4YTA==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
#### What does this PR do? 

Add country select/dropdown, that sets the country options in selector automatically.
We had one on `gc-utils`.

#### How to test it? 

https://selectcountry--gc-hmo3203.myvtex.com.br/admin/settings/general

Test country selection in "address" card, should also change names when changing language.

#### Describe alternatives you've considered, if any. 

This is meant to be used in `admin-settings` which I'm refactoring to use `Form` from `form-utils` and trying not to use `gc-utils`.
**Another option** is to do this feature inside `admin-settings` if not used elsewhere.

#### Related to / Depends on
